### PR TITLE
fix(workflow): ensure we run on node 19

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -10,6 +10,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Setup Node 19
+        uses: actions/setup-node@v3
+        with:
+          node-version: '19'
+
       - name: npm-install
         run: npm install
       

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -10,6 +10,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Setup Node 19
+        uses: actions/setup-node@v3
+        with:
+          node-version: '19'
+
       - name: npm-install
         run: npm install
       

--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -12,6 +12,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
 
+    - name: Setup Node 19
+        uses: actions/setup-node@v3
+        with:
+          node-version: '19'
+
     - name: vuepress-deploy
       uses: jenkey2011/vuepress-deploy@v1.8.1
       env:


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

We lately had unstable builds depending on the machine we got assigned int he workflow. We either had a node 17+ or 16- and therefore the openssl change interrupted our builds and tests.

This PR ensure we check out the correct node version before running things.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
