### PR TITLE
fix(workflow): use vuepress deploy master

### DIFF
--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -18,7 +18,7 @@ jobs:
         node-version: '19'
 
     - name: vuepress-deploy
-      uses: jenkey2011/vuepress-deploy@v1.8.1
+      uses: jenkey2011/vuepress-deploy@master
       env:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         TARGET_REPO: IT4Change/IT4C.dev


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

There is a conflict between the node-versions. We use node 19+ while vuepress-deploy uses 16+.
If using the latest version of vuepress-deploy does not fix this, we need to provide a special command for the vuepress deploy, which does not submit the legacy node option for ssl.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
