### PR TITLE
fix(workflow): implement node 16 compatible mode for building

### DIFF
--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -23,6 +23,6 @@ jobs:
         ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         TARGET_REPO: IT4Change/IT4C.dev
         TARGET_BRANCH: gh-pages
-        BUILD_SCRIPT: npm install && npm run build
+        BUILD_SCRIPT: npm install && npm run build-node16
         BUILD_DIR: docs/.vuepress/dist
         CNAME: https://www.it4c.dev

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "NODE_OPTIONS=--openssl-legacy-provider vuepress build docs",
+    "build-node16": "vuepress build docs",
     "dev": "NODE_OPTIONS=--openssl-legacy-provider vuepress dev docs",
     "test": "textlint \"*.md\" \"docs/**/*.md\""
   },


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

implement node 16 compatible mode for building.

This is required since the vuepress-deploy environment supplies its own node environment and uses our commands and code supplied. We need to make sure there is node 16 compatibility till the library is updated.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
