### PR TITLE
fix(other): deploy.sh properly overwrite symbolic link

### DIFF
--- a/.github/webhooks/deploy.sh
+++ b/.github/webhooks/deploy.sh
@@ -26,4 +26,4 @@ npm run build
 # Copy files and Sym link
 mkdir $DEPLOY_DIR_REF/
 cp -r $BUILD_DIR/* $DEPLOY_DIR_REF/
-ln -sf $DEPLOY_DIR_REF $DEPLOY_DIR
+ln -sfn $DEPLOY_DIR_REF $DEPLOY_DIR


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

deploy.sh properly overwrite symbolic link.
The current implementation on master resolved the symbolic link and wrote it in the referenced folder
Solution from: https://stackoverflow.com/questions/5250345/cannot-overwrite-symbolic-link-redhat-linux

![image](https://github.com/IT4Change/IT4C.dev/assets/1238238/0460c45e-20f7-430d-a7ba-1962a5c22724)

![image](https://github.com/IT4Change/IT4C.dev/assets/1238238/9e75bb8e-641e-475e-a59d-bdffa3188253)

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
