### PR TITLE
chore(other): set dependabot package update pr limit to none

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
 version: 2
+open-pull-requests-limit: 0
 updates:
 
 - package-ecosystem: "github-actions"


### PR DESCRIPTION
## 🍰 Pullrequest
Thanks to @ulfgebhardt's observations, we noticed that dependabotper default only generates 5 package update bump pull requests.
This change removes this limitation.
