### PR TITLE
refactor(workflow): pin all github actions by commit hash

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
 
       - name: Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.3
         with:
           node-version: '20'
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Node 20
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.3

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
 
       - name: Setup Node 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.3
         with:
           node-version: '20'
 

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Node 20
         uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.3

--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
 
     - name: vuepress-deploy
       uses: IT4Change/vuepress-build-and-deploy@master

--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.7
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
     - name: vuepress-deploy
       uses: IT4Change/vuepress-build-and-deploy@master


### PR DESCRIPTION
Motivation
----------
[This comment](https://github.com/dreammall-earth/dreammall.earth/pull/1669#pullrequestreview-2217555113) on Github Action versions in Github workflows emphasizes the importance of taking measures to reduce the risk of being affected by supply chain attacks. One Measure is pinning the Github Actions in our workflows by commit hash rather than by tag.


How to test
----------
Just see the workflows work.