### PR TITLE
refactor(other): add automerge for dependabot pull requests

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,15 @@
+name: auto-merge
+
+on:
+  pull_request:
+
+jobs:
+  auto-merge:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: minor
+          github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -8,8 +8,8 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - uses: ahmadnassri/action-dependabot-auto-merge@4b9c6f0185a1c94f18bc293dc050c8c073b4fcc8 #v2.6.6
         with:
           target: minor
           github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
Motivation
------
We use a manageable number of packages for the website - [3 Vuepress packages and the rest are textlint packages](https://github.com/IT4Change/IT4C.dev/blob/master/package.json).
We have never had any major problems with the package updates.

Adding Automerge for the Dependabot minor version bump PRs makes website maintenance much easier.

