### PR TITLE
refactor(workflow): add required permissions to pr workflow

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: write
+  pull-requests: read
   statuses: write
 
 jobs:

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -7,7 +7,7 @@ on:
       - edited
       - synchronize
 
-  permissions:
+permissions:
   pull-requests: write
   statuses: write
 

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: amannn/action-semantic-pull-request@40166f00814508ec3201fc8595b393d451c8cd80 # v5.5.3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           # Configure which types are allowed (newline delimited).
           # Default: https://github.com/commitizen/conventional-commit-types

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -8,7 +8,11 @@ on:
       - synchronize
 
 permissions:
+  actions: write
+  attestations: write
+  checks: write
   contents: write
+  id-token: write
   pull-requests: write
   statuses: write
 

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -7,7 +7,11 @@ on:
       - edited
       - synchronize
 
-jobs:
+  permissions:
+  pull-requests: write
+  statuses: write
+
+  jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -8,7 +8,8 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  contents: write
+  pull-requests: write
   statuses: write
 
 jobs:

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -11,7 +11,7 @@ on:
   pull-requests: write
   statuses: write
 
-  jobs:
+jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@40166f00814508ec3201fc8595b393d451c8cd80 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## 🍰 Pullrequest
The Github action used in the PR linting workflow [cannot access the pr data properly](https://github.com/IT4Change/IT4C.dev/actions/runs/13018646171/job/36313938297?pr=209).
Setting the required permissions fixes that.

