### PR TITLE
refactor(other): set site language to german

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -4,6 +4,7 @@ import meta from './config/meta'
 import theme from './config/theme'
 
 export default defineUserConfig({
+  lang: 'de-DE',
   ...meta,
   theme,
   bundler: viteBundler({}),


### PR DESCRIPTION
## 🍰 Pullrequest
Vuepress' [default language is Einglish](https://vuepress.vuejs.org/reference/config.html#lang).

Thus, all Vuepress control elements of the website are labeled in English, as seen in this example:
![site_elements
_default_english](https://github.com/user-attachments/assets/7c049f07-7925-4be7-ad5a-ca7fbbb44acf)


Setting the defalut language to German labels all control elements German:
![site_elements_german](https://github.com/user-attachments/assets/8065205d-bf4a-4aee-9f60-1617e309ce59)
