### PR TITLE
refactor(other): remove print button

### DIFF
--- a/docs/.vuepress/config/theme.js
+++ b/docs/.vuepress/config/theme.js
@@ -8,6 +8,7 @@ export default hopeTheme({
   editLink: true,
   lastUpdated: false,
   contributors: false,
+  print: false,
   displayFooter: true,
   pageInfo: false,
   footer: 'CC BY IT4C.dev & Authors - <a href="/imprint.html">Imprint</a>',


### PR DESCRIPTION
## 🍰 Pullrequest
![print_button](https://github.com/user-attachments/assets/2820108f-a81e-4fc6-92eb-5557c9350124)

The Print button is activated by default.
The functionality and quality behind it is the same as the standard way of printing the current page displayed in the browser.

Therefore, the Print button is not required.