### PR TITLE
fix(other): better quality on jpeg images

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -19,7 +19,7 @@ export default defineUserConfig({
         optimizationLevel: 7,
       },
       mozjpeg: {
-        quality: 20,
+        quality: 100,
       },
       pngquant: {
         quality: [0.8, 0.9],


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

images - better quality on jpeg images

Set the quality requirement for the jpeg optimization to 100% instead of 20%

The new Settings produce these filesizes:
![image](https://github.com/user-attachments/assets/380ab0cf-4fec-44a7-99a6-4ff940218ca6)

The old (20%) settings produced this:
![image](https://github.com/user-attachments/assets/2ab67d4d-04c4-4fec-aa06-9fab2c6ab561)

We have 20% increased file size compared to the settings before, but still 60%+ compression.

### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- None

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
