### PR TITLE
fix(other): fix tailwind

### DIFF
--- a/docs/.vuepress/layouts/BlankLayout.vue
+++ b/docs/.vuepress/layouts/BlankLayout.vue
@@ -12,8 +12,23 @@ export default {
 </script>
 
 <style>
-@import "tailwindcss/theme.css";
-@import "tailwindcss/utilities.css";
+@layer theme, base, components, utilities;
+
+@import "tailwindcss/theme.css" layer(theme);
+@import "tailwindcss/preflight.css" layer(base);
+@import "tailwindcss/utilities.css" layer(utilities);
+
+/* Conflicts with vuepress */
+@layer base {
+  /* sidebar */
+  * {
+    box-sizing: content-box;
+  }
+  /* Menu Icon */
+  img, svg, video, canvas, audio, iframe, embed, object {
+    display: inline;
+  }
+}
 
 .blank-layout {
   --content-width: 1160px;

--- a/docs/.vuepress/layouts/BlankLayout.vue
+++ b/docs/.vuepress/layouts/BlankLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="theme-container">
+  <div class="theme-container blank-layout">
     <Content />
     <Footer />
   </div>
@@ -10,3 +10,35 @@ export default {
   name: 'BlankLayout'
 }
 </script>
+
+<style>
+@import "tailwindcss/theme.css";
+@import "tailwindcss/utilities.css";
+
+.blank-layout {
+  --content-width: 1160px;
+}
+
+.blank-layout h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-family-heading);
+  }
+
+.blank-layout h1, h2 {
+  border-bottom: none;
+  padding-bottom: 2rem;
+  font-weight: bold;
+}
+
+.blank-layout .content-width {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 0 2.5rem;
+
+  @media (max-width: 768px) {
+    padding: 0 1.75rem;
+  }
+  @media (max-width: 400px) {
+    padding: 0 1rem;
+  }
+}
+</style>

--- a/docs/.vuepress/layouts/BlankLayout.vue
+++ b/docs/.vuepress/layouts/BlankLayout.vue
@@ -20,12 +20,10 @@ export default {
 
 /* Conflicts with vuepress */
 @layer base {
-  /* sidebar */
-  * {
+  .vp-sidebar {
     box-sizing: content-box;
   }
-  /* Menu Icon */
-  img, svg, video, canvas, audio, iframe, embed, object {
+  .vp-nav-logo {
     display: inline;
   }
 }

--- a/docs/.vuepress/styles/index.scss
+++ b/docs/.vuepress/styles/index.scss
@@ -1,8 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&family=Source+Sans+3:wght@400;500;600&display=swap');
 
 :root {
-  --content-width: 1160px;
-
   --font-family: 'Source Sans 3', sans-serif;
   --font-family-heading: 'Montserrat', sans-serif;
 
@@ -11,24 +9,12 @@
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-family-heading);
+  font-family: 'Montserrat', sans-serif !important;
+}
+.font-montserrat {
+  font-family: 'Montserrat', sans-serif !important;
 }
 
-h1, h2 {
-  border-bottom: none;
-  padding-bottom: 2rem;
-  font-weight: bold;
-}
-
-.content-width {
-  max-width: var(--content-width);
-  margin: 0 auto;
-  padding: 0 2.5rem;
-
-  @media (max-width: 768px) {
-    padding: 0 1.75rem;
-  }
-  @media (max-width: 400px) {
-    padding: 0 1rem;
-  }
+.font-sourcesans {
+  font-family: 'Source Sans 3', sans-serif !important;
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,23 +190,6 @@ layout: BlankLayout
   <ContactForm />
 </ContentSection>
 
-
-<style>
-  @import "tailwindcss";
-  
-  h1, h2, h3, h4, h5, h6 {
-    font-family: 'Montserrat', sans-serif !important;
-  }
-  
-  .font-montserrat {
-    font-family: 'Montserrat', sans-serif !important;
-  }
-
-  .font-sourcesans {
-    font-family: 'Source Sans 3', sans-serif !important;
-  }
-</style>
-
 <style lang="scss">
   .text-shadow {
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
<!-- You can find the latest issue templates here https://github.com/ulfgebhardt/issue-templates -->

## 🍰 Pullrequest
<!-- Describe the Pullrequest. Use Screenshots if possible. -->

Difference to production:
- the style `space-y-2`  now properly applies to the list items. They are now further apart.
In the picture you can see the new style except on `Beratung & Betreuung` where the old style is applied
![image](https://github.com/user-attachments/assets/2a3fc0ed-4077-438a-b5ed-ab53255c45eb)

- Content width on vuepress differs now from the landing page
- Logo on Navbar is now always in one line

New:
![image](https://github.com/user-attachments/assets/bb481206-abc4-43a1-90c7-e665bddce4ba)

Before:
![image](https://github.com/user-attachments/assets/f76c0196-6f49-4f25-8517-64a21f9829cd)


### Issues
<!-- Which Issues does this fix, which are related?
- fixes #XXX
- relates #XXX
-->
- fixes https://github.com/IT4Change/IT4C.dev/issues/283
- fixes https://github.com/IT4Change/IT4C.dev/issues/284

### Todo
<!-- In case some parts are still missing, list them here. -->
- [X] None
